### PR TITLE
remove --disable-instrumentation from cargo fuzz build

### DIFF
--- a/.github/workflows/mayhem.yml
+++ b/.github/workflows/mayhem.yml
@@ -45,6 +45,7 @@ jobs:
     name: 'fuzz ${{ matrix.mayhemfile }}'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         mayhemfile:
           - mayhem/pdu_roundtrip.mayhemfile

--- a/mayhem/Dockerfile
+++ b/mayhem/Dockerfile
@@ -6,21 +6,24 @@ ADD . /src
 WORKDIR /src
 
 RUN echo building instrumented harnesses && \
-    cargo +nightly -Z sparse-registry fuzz build --fuzz-dir ul/fuzz && \
-    cargo +nightly -Z sparse-registry fuzz build --fuzz-dir object/fuzz && \
+    bash -c "pushd ul/fuzz && cargo +nightly -Z sparse-registry fuzz build && popd" && \
+    bash -c "pushd object/fuzz && cargo +nightly -Z sparse-registry fuzz build && popd" && \
     mv ul/fuzz/target/x86_64-unknown-linux-gnu/release/pdu_roundtrip /pdu_roundtrip && \
     mv object/fuzz/target/x86_64-unknown-linux-gnu/release/open_file /open_file && \
     echo done
 
 RUN echo building non-instrumented harnesses && \
-    cargo +nightly -Z sparse-registry fuzz build --fuzz-dir ul/fuzz --disable-instrumentation && \
-    cargo +nightly -Z sparse-registry fuzz build --fuzz-dir object/fuzz --disable-instrumentation && \
-    mv ul/fuzz/target/x86_64-unknown-linux-gnu/release/pdu_roundtrip /pdu_roundtrip_no_inst && \
-    mv object/fuzz/target/x86_64-unknown-linux-gnu/release/open_file /open_file_no_inst && \
+    export RUSTFLAGS="--cfg fuzzing -Clink-dead-code -Cdebug-assertions -C codegen-units=1" && \
+    bash -c "pushd ul/fuzz && cargo +nightly -Z sparse-registry build --release && popd" && \
+    bash -c "pushd object/fuzz && cargo +nightly -Z sparse-registry build --release && popd" && \
+    mv ul/fuzz/target/release/pdu_roundtrip /pdu_roundtrip_no_inst && \
+    mv object/fuzz/target/release/open_file /open_file_no_inst && \
     echo done
 
 # Package Stage
 FROM rustlang/rust:nightly
 
-COPY --from=builder /pdu_roundtrip  /pdu_roundtrip_no_inst /
-COPY --from=builder /open_file  /open_file_no_inst /
+COPY --from=builder /pdu_roundtrip /pdu_roundtrip_no_inst /
+COPY --from=builder /open_file /open_file_no_inst /
+
+ENV ASAN_OPTIONS=allocator_may_return_null=1:max_allocation_size_mb=40


### PR DESCRIPTION
`--disable-instrumentation` was planned to be upstreamed to cargo-fuzz, and as such, its an unsupported feature only in my fork. The PR contains better alternative: https://github.com/rust-fuzz/cargo-fuzz/pull/315

This change applies the outcome of that, so that the build image can use vanilla cargo-fuzz features